### PR TITLE
Refactor lastAttackedBy to hurtBy

### DIFF
--- a/data/moves.js
+++ b/data/moves.js
@@ -949,7 +949,7 @@ let BattleMovedex = {
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
 			let hurtByTarget = pokemon.hurtBy.find(function (x) {
-				return x.source === target && x.damage > 0;
+				return x.source === target && x.damage > 0 && x.thisTurn;
 			});
 			if (hurtByTarget) {
 				this.debug('Boosted for getting hit by ' + hurtByTarget.move);
@@ -13392,7 +13392,7 @@ let BattleMovedex = {
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
 			let hurtByTarget = pokemon.hurtBy.find(function (x) {
-				return x.source === target && x.damage > 0;
+				return x.source === target && x.damage > 0 && x.thisTurn;
 			});
 			if (hurtByTarget) {
 				this.debug('Boosted for getting hit by ' + hurtByTarget.move);

--- a/data/moves.js
+++ b/data/moves.js
@@ -948,8 +948,11 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (target.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.pokemon === target) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
+			let hurtByTarget = pokemon.hurtBy.find(function (x) {
+				return x.source === target && x.damage > 0;
+			});
+			if (hurtByTarget) {
+				this.debug('Boosted for getting hit by ' + hurtByTarget.move);
 				return move.basePower * 2;
 			}
 			return move.basePower;
@@ -13388,8 +13391,11 @@ let BattleMovedex = {
 		accuracy: 100,
 		basePower: 60,
 		basePowerCallback: function (pokemon, target, move) {
-			if (target.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.pokemon === target) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
+			let hurtByTarget = pokemon.hurtBy.find(function (x) {
+				return x.source === target && x.damage > 0;
+			});
+			if (hurtByTarget) {
+				this.debug('Boosted for getting hit by ' + hurtByTarget.move);
 				return move.basePower * 2;
 			}
 			return move.basePower;

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -967,11 +967,11 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				if (!target.lastAttackedBy) {
-					target.lastAttackedBy = {pokemon: source, move: move.id, thisTurn: true, damage: damage};
+				if (target.hurtBy.length == 0) {
+					target.hurtBy.push({source: source, move: move.id, damage: damage});
 				} else {
-					target.lastAttackedBy.move = move.id;
-					target.lastAttackedBy.damage = damage;
+					target.hurtBy[0].move = move.id;
+					target.hurtBy[0].damage = damage;
 				}
 				return 0;
 			},

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -970,8 +970,8 @@ let BattleMovedex = {
 				if (target.hurtBy.length == 0) {
 					target.hurtBy.push({source: source, move: move.id, damage: damage});
 				} else {
-					target.hurtBy[0].move = move.id;
-					target.hurtBy[0].damage = damage;
+					target.hurtBy[target.hurtBy.length - 1].move = move.id;
+					target.hurtBy[target.hurtBy.length - 1].damage = damage;
 				}
 				return 0;
 			},

--- a/mods/gen1/moves.js
+++ b/mods/gen1/moves.js
@@ -968,7 +968,7 @@ let BattleMovedex = {
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
 				if (target.hurtBy.length == 0) {
-					target.hurtBy.push({source: source, move: move.id, damage: damage});
+					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
 					target.hurtBy[target.hurtBy.length - 1].move = move.id;
 					target.hurtBy[target.hurtBy.length - 1].damage = damage;

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -144,9 +144,11 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a physical attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a physical attack this turn, or if the user did not lose HP from the attack. If the opposing Pokemon used Fissure or Horn Drill and missed, this move deals 65535 damage.",
 		damageCallback: function (pokemon, target) {
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && (this.getCategory(pokemon.lastAttackedBy.move) === 'Physical' || this.getMove(pokemon.lastAttackedBy.move).id === 'hiddenpower') &&
+			if (pokemon.hurtBy.length == 0) return false;
+			let lastHurtBy = pokemon.hurtBy[0];
+			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower') &&
 				(!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * pokemon.lastAttackedBy.damage;
+				return 2 * lastHurtBy.damage;
 			}
 			return false;
 		},
@@ -493,9 +495,11 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && this.getCategory(pokemon.lastAttackedBy.move) === 'Special' &&
-				this.getMove(pokemon.lastAttackedBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
-				return 2 * pokemon.lastAttackedBy.damage;
+			if (pokemon.hurtBy.length == 0) return false;
+			let lastHurtBy = pokemon.hurtBy[0];
+			if (lastHurtBy.move && this.getCategory(lastHurtBy.move) === 'Special' &&
+				this.getMove(lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
+				return 2 * lastHurtBy.damage;
 			}
 			return false;
 		},

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -146,7 +146,7 @@ let BattleMovedex = {
 		damageCallback: function (pokemon, target) {
 			if (pokemon.hurtBy.length == 0) return false;
 			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
-			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower') &&
+			if (lastHurtBy.move && && lastHurtBy.thisTurn && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower') &&
 				(!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * lastHurtBy.damage;
 			}
@@ -497,7 +497,7 @@ let BattleMovedex = {
 		damageCallback: function (pokemon, target) {
 			if (pokemon.hurtBy.length == 0) return false;
 			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
-			if (lastHurtBy.move && this.getCategory(lastHurtBy.move) === 'Special' &&
+			if (lastHurtBy.move && lastHurtBy.thisTurn && this.getCategory(lastHurtBy.move) === 'Special' &&
 				this.getMove(lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * lastHurtBy.damage;
 			}

--- a/mods/gen2/moves.js
+++ b/mods/gen2/moves.js
@@ -145,7 +145,7 @@ let BattleMovedex = {
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a physical attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a physical attack this turn, or if the user did not lose HP from the attack. If the opposing Pokemon used Fissure or Horn Drill and missed, this move deals 65535 damage.",
 		damageCallback: function (pokemon, target) {
 			if (pokemon.hurtBy.length == 0) return false;
-			let lastHurtBy = pokemon.hurtBy[0];
+			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
 			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower') &&
 				(!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * lastHurtBy.damage;
@@ -496,7 +496,7 @@ let BattleMovedex = {
 		desc: "Deals damage to the opposing Pokemon equal to twice the HP lost by the user from a special attack this turn. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user moves first, if the user was not hit by a special attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon, target) {
 			if (pokemon.hurtBy.length == 0) return false;
-			let lastHurtBy = pokemon.hurtBy[0];
+			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
 			if (lastHurtBy.move && this.getCategory(lastHurtBy.move) === 'Special' &&
 				this.getMove(lastHurtBy.move).id !== 'hiddenpower' && (!target.lastMove || target.lastMove.id !== 'sleeptalk')) {
 				return 2 * lastHurtBy.damage;

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -189,7 +189,7 @@ let BattleMovedex = {
 		damageCallback: function (pokemon) {
 			if (pokemon.hurtBy.length == 0) return false;
 			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
-			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower')) {
+			if (lastHurtBy.move && lastHurtBy.thisTurn && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
 				return 2 * lastHurtBy.damage;
 			}

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -187,9 +187,11 @@ let BattleMovedex = {
 		inherit: true,
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon) {
-			if (pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn && pokemon.lastAttackedBy.move && (this.getCategory(pokemon.lastAttackedBy.move) === 'Physical' || this.getMove(pokemon.lastAttackedBy.move).id === 'hiddenpower')) {
+			if (pokemon.hurtBy.length == 0) return false;
+			let lastHurtBy = pokemon.hurtBy[0];
+			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
-				return 2 * pokemon.lastAttackedBy.damage;
+				return 2 * lastHurtBy.damage;
 			}
 			return false;
 		},
@@ -557,10 +559,12 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['assist', 'curse', 'doomdesire', 'focuspunch', 'futuresight', 'magiccoat', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'psychup', 'roleplay', 'sketch', 'sleeptalk', 'spikes', 'spitup', 'taunt', 'teeterdance', 'transform'];
-			if (!pokemon.lastAttackedBy || !pokemon.lastAttackedBy.pokemon.lastMove || !pokemon.lastAttackedBy.move || noMirror.includes(pokemon.lastAttackedBy.move) || !pokemon.lastAttackedBy.pokemon.hasMove(pokemon.lastAttackedBy.move)) {
+			if (pokemon.hurtBy.length == 0) return false;
+			let lastHurtBy = pokemon.hurtBy[0];
+			if (!lastHurtBy.pokemon.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.pokemon.hasMove(lastHurtBy.move)) {
 				return false;
 			}
-			this.useMove(pokemon.lastAttackedBy.move, pokemon);
+			this.useMove(lastHurtBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gen3/moves.js
+++ b/mods/gen3/moves.js
@@ -188,7 +188,7 @@ let BattleMovedex = {
 		desc: "Deals damage to the last opposing Pokemon to hit the user with a physical attack this turn equal to twice the HP lost by the user from that attack. If that opposing Pokemon's position is no longer in use and there is another opposing Pokemon on the field, the damage is done to it instead. This move considers Hidden Power as Normal type, and only the last hit of a multi-hit attack is counted. Fails if the user was not hit by an opposing Pokemon's physical attack this turn, or if the user did not lose HP from the attack.",
 		damageCallback: function (pokemon) {
 			if (pokemon.hurtBy.length == 0) return false;
-			let lastHurtBy = pokemon.hurtBy[0];
+			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
 			if (lastHurtBy.move && (this.getCategory(lastHurtBy.move) === 'Physical' || this.getMove(lastHurtBy.move).id === 'hiddenpower')) {
 				// @ts-ignore
 				return 2 * lastHurtBy.damage;
@@ -560,7 +560,7 @@ let BattleMovedex = {
 		onHit: function (pokemon) {
 			let noMirror = ['assist', 'curse', 'doomdesire', 'focuspunch', 'futuresight', 'magiccoat', 'metronome', 'mimic', 'mirrormove', 'naturepower', 'psychup', 'roleplay', 'sketch', 'sleeptalk', 'spikes', 'spitup', 'taunt', 'teeterdance', 'transform'];
 			if (pokemon.hurtBy.length == 0) return false;
-			let lastHurtBy = pokemon.hurtBy[0];
+			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
 			if (!lastHurtBy.pokemon.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.pokemon.hasMove(lastHurtBy.move)) {
 				return false;
 			}

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1104,10 +1104,12 @@ let BattleMovedex = {
 		onTryHit: function () { },
 		onHit: function (pokemon) {
 			let noMirror = ['acupressure', 'aromatherapy', 'assist', 'chatter', 'copycat', 'counter', 'curse', 'doomdesire', 'feint', 'focuspunch', 'futuresight', 'gravity', 'hail', 'haze', 'healbell', 'helpinghand', 'lightscreen', 'luckychant', 'magiccoat', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'mist', 'mudsport', 'naturepower', 'perishsong', 'psychup', 'raindance', 'reflect', 'roleplay', 'safeguard', 'sandstorm', 'sketch', 'sleeptalk', 'snatch', 'spikes', 'spitup', 'stealthrock', 'struggle', 'sunnyday', 'tailwind', 'toxicspikes', 'transform', 'watersport'];
-			if (!pokemon.lastAttackedBy || !pokemon.lastAttackedBy.pokemon.lastMove || !pokemon.lastAttackedBy.move || noMirror.includes(pokemon.lastAttackedBy.move) || !pokemon.lastAttackedBy.pokemon.hasMove(pokemon.lastAttackedBy.move)) {
-				return false;
+			if (pokemon.hurtBy.length == 0) return false;
+			let lastHurtBy = pokemon.hurtBy[0];
+			if (!lastHurtBy.source.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.source.hasMove(lastHurtBy.move)) {
+				 return false;
 			}
-			this.useMove(pokemon.lastAttackedBy.move, pokemon);
+			this.useMove(lastHurtBy.move, pokemon);
 		},
 		target: "self",
 	},

--- a/mods/gen4/moves.js
+++ b/mods/gen4/moves.js
@@ -1105,7 +1105,7 @@ let BattleMovedex = {
 		onHit: function (pokemon) {
 			let noMirror = ['acupressure', 'aromatherapy', 'assist', 'chatter', 'copycat', 'counter', 'curse', 'doomdesire', 'feint', 'focuspunch', 'futuresight', 'gravity', 'hail', 'haze', 'healbell', 'helpinghand', 'lightscreen', 'luckychant', 'magiccoat', 'mefirst', 'metronome', 'mimic', 'mirrorcoat', 'mirrormove', 'mist', 'mudsport', 'naturepower', 'perishsong', 'psychup', 'raindance', 'reflect', 'roleplay', 'safeguard', 'sandstorm', 'sketch', 'sleeptalk', 'snatch', 'spikes', 'spitup', 'stealthrock', 'struggle', 'sunnyday', 'tailwind', 'toxicspikes', 'transform', 'watersport'];
 			if (pokemon.hurtBy.length == 0) return false;
-			let lastHurtBy = pokemon.hurtBy[0];
+			let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
 			if (!lastHurtBy.source.lastMove || !lastHurtBy.move || noMirror.includes(lastHurtBy.move) || !lastHurtBy.source.hasMove(lastHurtBy.move)) {
 				 return false;
 			}

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -973,9 +973,12 @@ let BattleMovedex = {
 	avalanche: {
 		inherit: true,
 		basePowerCallback: function (pokemon, source) {
-			if ((pokemon.hurtBy.length > 0 && pokemon.hurtBy[pokemon.hurtBy.length - 1].damage > 0)) {
-				this.debug('Boosted for getting hit by ' + pokemon.hurtBy[pokemon.hurtBy.length - 1].move);
-				return this.isWeather('hail') ? 180 : 120;
+			if (pokemon.hurtBy.length > 0) {
+				let lastHurtBy = pokemon.hurtBy[pokemon.hurtBy.length - 1];
+				if (lastHurtBy.damage > 0 && lastHurtBy.thisTurn) {
+					this.debug('Boosted for getting hit by ' + lastHurtBy.move);
+					return this.isWeather('hail') ? 180 : 120;
+				}
 			}
 			return this.isWeather('hail') ? 90 : 60;
 		},

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -973,8 +973,8 @@ let BattleMovedex = {
 	avalanche: {
 		inherit: true,
 		basePowerCallback: function (pokemon, source) {
-			if ((source.lastDamage > 0 && pokemon.lastAttackedBy && pokemon.lastAttackedBy.thisTurn)) {
-				this.debug('Boosted for getting hit by ' + pokemon.lastAttackedBy.move);
+			if ((pokemon.hurtBy.length > 0 && pokemon.hurtBy[0].damage > 0)) {
+				this.debug('Boosted for getting hit by ' + pokemon.hurtBy[0].move);
 				return this.isWeather('hail') ? 180 : 120;
 			}
 			return this.isWeather('hail') ? 90 : 60;

--- a/mods/gennext/moves.js
+++ b/mods/gennext/moves.js
@@ -973,8 +973,8 @@ let BattleMovedex = {
 	avalanche: {
 		inherit: true,
 		basePowerCallback: function (pokemon, source) {
-			if ((pokemon.hurtBy.length > 0 && pokemon.hurtBy[0].damage > 0)) {
-				this.debug('Boosted for getting hit by ' + pokemon.hurtBy[0].move);
+			if ((pokemon.hurtBy.length > 0 && pokemon.hurtBy[pokemon.hurtBy.length - 1].damage > 0)) {
+				this.debug('Boosted for getting hit by ' + pokemon.hurtBy[pokemon.hurtBy.length - 1].move);
 				return this.isWeather('hail') ? 180 : 120;
 			}
 			return this.isWeather('hail') ? 90 : 60;

--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -162,8 +162,8 @@ let BattleMovedex = {
 				if (target.hurtBy.length == 0) {
 					target.hurtBy.push({source: source, move: move.id, damage: damage});
 				} else {
-					target.hurtBy[0].move = move.id;
-					target.hurtBy[0].damage = damage;
+					target.hurtBy[target.hurtBy.length - 1].move = move.id;
+					target.hurtBy[target.hurtBy.length - 1].damage = damage;
 				}
 				return 0;
 			},

--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -159,11 +159,11 @@ let BattleMovedex = {
 				}
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
-				if (!target.lastAttackedBy) {
-					target.lastAttackedBy = {pokemon: source, move: move.id, thisTurn: true, damage: damage};
+				if (target.hurtBy.length == 0) {
+					target.hurtBy.push({source: source, move: move.id, damage: damage});
 				} else {
-					target.lastAttackedBy.move = move.id;
-					target.lastAttackedBy.damage = damage;
+					target.hurtBy[0].move = move.id;
+					target.hurtBy[0].damage = damage;
 				}
 				return 0;
 			},

--- a/mods/stadium/moves.js
+++ b/mods/stadium/moves.js
@@ -160,7 +160,7 @@ let BattleMovedex = {
 				this.runEvent('AfterSubDamage', target, source, move, damage);
 				// Add here counter damage
 				if (target.hurtBy.length == 0) {
-					target.hurtBy.push({source: source, move: move.id, damage: damage});
+					target.hurtBy.push({source: source, move: move.id, damage: damage, thisTurn: true});
 				} else {
 					target.hurtBy[target.hurtBy.length - 1].move = move.id;
 					target.hurtBy[target.hurtBy.length - 1].damage = damage;

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1545,7 +1545,7 @@ class Battle extends Dex.ModdedDex {
 				// If it was an illusion, it's not any more
 				if (pokemon.hurtBy.length > 0 && this.gen >= 7) pokemon.knownType = true;
 				
-				for (let i = pokemon.hurtBy.length; i >= 0; i--) {
+				for (let i = pokemon.hurtBy.length - 1; i >= 0; i--) {
 					let attack = pokemon.hurtBy[i];
 					if (attack.source.isActive) {
 						attack.thisTurn = false;

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1544,7 +1544,15 @@ class Battle extends Dex.ModdedDex {
 
 				// If it was an illusion, it's not any more
 				if (pokemon.hurtBy.length > 0 && this.gen >= 7) pokemon.knownType = true;
-				pokemon.hurtBy = [];
+				
+				for (let i = pokemon.hurtBy.length; i >= 0; i--) {
+					let attack = pokemon.hurtBy[i];
+					if (attack.source.isActive) {
+						attack.thisTurn = false;
+					} else {
+						pokemon.hurtBy.slice(pokemon.hurtBy.indexof(attack), 1);
+					}
+				}
 
 				if (this.gen >= 7) {
 					// In Gen 7, the real type of every Pokemon is visible to all players via the bottom screen while making choices

--- a/sim/battle.js
+++ b/sim/battle.js
@@ -1542,14 +1542,9 @@ class Battle extends Dex.ModdedDex {
 				this.runEvent('DisableMove', pokemon);
 				if (!pokemon.ateBerry) pokemon.disableMove('belch');
 
-				if (pokemon.lastAttackedBy) {
-					if (pokemon.lastAttackedBy.pokemon.isActive) {
-						pokemon.lastAttackedBy.thisTurn = false;
-					} else {
-						pokemon.lastAttackedBy = null;
-					}
-					if (this.gen >= 7) pokemon.knownType = true; // If it was an illusion, it's not any more
-				}
+				// If it was an illusion, it's not any more
+				if (pokemon.hurtBy.length > 0 && this.gen >= 7) pokemon.knownType = true;
+				pokemon.hurtBy = [];
 
 				if (this.gen >= 7) {
 					// In Gen 7, the real type of every Pokemon is visible to all players via the bottom screen while making choices

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -606,6 +606,7 @@ class Pokemon {
 			source: source,
 			damage: damage,
 			move: move.id,
+			thisTurn: true,
 		};
 		this.hurtBy.push(lastHurtBy);
 	}

--- a/sim/pokemon.js
+++ b/sim/pokemon.js
@@ -156,7 +156,7 @@ class Pokemon {
 
 		this.lastDamage = 0;
 		/**@type {?{pokemon: Pokemon, damage: number, thisTurn: boolean, move?: string}} */
-		this.lastAttackedBy = null;
+		this.hurtBy = [];
 		this.usedItemThisTurn = false;
 		this.newlySwitched = false;
 		this.beingCalledBack = false;
@@ -602,12 +602,12 @@ class Pokemon {
 	gotAttacked(move, damage, source) {
 		if (!damage) damage = 0;
 		move = this.battle.getMove(move);
-		this.lastAttackedBy = {
-			pokemon: source,
+		let lastHurtBy = {
+			source: source,
 			damage: damage,
 			move: move.id,
-			thisTurn: true,
 		};
+		this.hurtBy.push(lastHurtBy);
 	}
 
 	/**
@@ -1022,7 +1022,7 @@ class Pokemon {
 		this.moveThisTurn = '';
 
 		this.lastDamage = 0;
-		this.lastAttackedBy = null;
+		this.hurtBy = [];
 		this.newlySwitched = true;
 		this.beingCalledBack = false;
 


### PR DESCRIPTION
Replaced the 'lastAttackedBy' attribute of a Pokemon with an array of attacks that the Pokemon has recently received. This corrects a bug in double battles arising from lastAttackedBy always getting replaced by the most recent attack, which caused Avalanche and Revenge to not double in power when they otherwise should have (e.g. see https://replay.pokemonshowdown.com/gen7doublescustomgame-796785834). This also addresses the corresponding task in 2444.